### PR TITLE
Add authors list to PluginYAML.java

### DIFF
--- a/src/main/java/org/jukeboxmc/plugin/PluginYAML.java
+++ b/src/main/java/org/jukeboxmc/plugin/PluginYAML.java
@@ -12,7 +12,7 @@ public class PluginYAML {
     public String version;
     public String author;
     public String main;
-
+    public List<String> authors;
     public List<String> depends;
 
     public String getAuthor() {
@@ -29,6 +29,10 @@ public class PluginYAML {
 
     public String getVersion() {
         return this.version;
+    }
+
+    public List<String> getAuthors() {
+        return this.authors;
     }
 
     public List<String> getDepends() {


### PR DESCRIPTION
Hi all!

I added the authors list to the PluginYAML.java class because it can happen that more than one author can work on a plugin. Just like it is with Spigot.