### PR TITLE
Fixed Error with "vector"

### DIFF
--- a/src/main/java/org/jukeboxmc/math/Vector.java
+++ b/src/main/java/org/jukeboxmc/math/Vector.java
@@ -130,9 +130,13 @@ public class Vector implements Cloneable {
     public int getChunkZ() {
         return this.getBlockZ() >> 4;
     }
-
-    public Dimension getDimension() {
+    
+    public Dimension checkDimensionIsNull() { // i've added this to fix <Cannot invoke "org.jukeboxmc.math.Vector.getDimension()" because "vector" is null> error
         return this.dimension;
+    }
+    
+    public Dimension getDimension() {
+        return (Vector.checkDimensionIsNull() == null) ? 0 : this.dimension;
     }
 
     public void setDimension( Dimension dimension ) {


### PR DESCRIPTION
Fixed <Exception in thread "JukeboxMC-Main" java.lang.NullPointerException: Cannot invoke "org.jukeboxmc.math.Vector.getDimension()" because "vector" is null> error